### PR TITLE
1 lookup node type

### DIFF
--- a/src/components/graph/SynthNodeInputs.jsx
+++ b/src/components/graph/SynthNodeInputs.jsx
@@ -1,7 +1,8 @@
 import { memo } from 'react';
 
 import './SynthNodeInputs.css'
-import { asRem, pxAsRem, remAsPx } from '../../lib/utils.js'
+import { asRem, pxAsRem, remAsPx, getItemById } from '../../lib/utils.js'
+import { getNodeTypeById } from '../../lib/synthNodeTypes.js'
 import { getSynthNodeTerminalIntentsById } from '../../lib/synthNodeIntents';
 import { nodeLayout } from '../../lib/nodeLayout.js'
 import usePatchStore from '../../store/patchStore.jsx'
@@ -10,6 +11,8 @@ const SynthNodeInputs = memo(function SynthNodeInputs(props) {
 
   const { synthNode } = props;
   const { inputs } = synthNode;
+  const nodeType = getNodeTypeById(synthNode.nodeTypeId);
+
   const { nodeVSpacing, nodeVOffset, labelPadding, dragLeft, dragRight, dragTop, dragBottom } = nodeLayout;
 
   const removeLinkFromInput = usePatchStore((state) => state.removeLinkFromInput);
@@ -62,8 +65,10 @@ const SynthNodeInputs = memo(function SynthNodeInputs(props) {
   return (
     (inputs || []).map(i => {
       if (i.exposed) {
+        const nodeTypeInput = getItemById(nodeType.inputs, i.id); // get matching input in synthNodeTypes
+
         const classCSS = `terminal ${
-          getSynthNodeTerminalIntentsById(i.intentId).classCSS
+          getSynthNodeTerminalIntentsById(nodeTypeInput.intentId).classCSS
         }`;
         const classCSSOutline = 'terminal outline';
 
@@ -76,10 +81,9 @@ const SynthNodeInputs = memo(function SynthNodeInputs(props) {
         const loosePosX = synthNode.x;
         const loosePosY = synthNode.y + i.posY;
 
-
         return (
           <g key={i.id} className="terminal-group">
-            <title>{i.description}</title>
+            <title>{nodeTypeInput.description}</title>
             <rect
               className={`drag-zone${ draggingLinkFromInput ? ' hidden' : ''}`}
               x={asRem(synthNode.x - dragLeft)}
@@ -132,7 +136,7 @@ const SynthNodeInputs = memo(function SynthNodeInputs(props) {
               className="terminal-input-label"
               x={asRem(synthNode.x + labelPadding)}
               y={asRem(synthNode.y + py + 0.06)}              
-            >{i.displayName}</text>
+            >{nodeTypeInput.displayName}</text>
           </g>
         )
       }

--- a/src/components/graph/SynthNodeOutputs.jsx
+++ b/src/components/graph/SynthNodeOutputs.jsx
@@ -1,6 +1,7 @@
 import './SynthNodeInputs.css' // deliberately Inputs
 import { memo } from 'react';
-import { asRem, pxAsRem, remAsPx } from '../../lib/utils.js'
+import { asRem, pxAsRem, remAsPx, getItemById } from '../../lib/utils.js'
+import { getNodeTypeById } from '../../lib/synthNodeTypes.js'
 import { getSynthNodeTerminalIntentsById } from '../../lib/synthNodeIntents';
 import { nodeLayout } from '../../lib/nodeLayout.js'
 import usePatchStore from '../../store/patchStore.jsx'
@@ -9,6 +10,8 @@ const SynthNodeOutputs = memo(function SynthNodeOutputs(props) {
 
   const { synthNode } = props;
   const { outputs } = synthNode;
+  const nodeType = getNodeTypeById(synthNode.nodeTypeId);
+
   const { nodeVSpacing, nodeVOffset, labelPadding, dragLeft, dragRight, dragTop, dragBottom } = nodeLayout;
 
   const removeLinksFromOutput = usePatchStore((state) => state.removeLinksFromOutput);
@@ -60,8 +63,10 @@ const SynthNodeOutputs = memo(function SynthNodeOutputs(props) {
   return (
     (outputs || []).map(i => {
       if (i.exposed) {
+        const nodeTypeOutput = getItemById(nodeType.outputs, i.id); // get matching input in synthNodeTypes
+
         const classCSS = `terminal ${
-          getSynthNodeTerminalIntentsById(i.intentId).classCSS
+          getSynthNodeTerminalIntentsById(nodeTypeOutput.intentId).classCSS
         }`;
         const classCSSOutline = `terminal outline`;
 
@@ -71,12 +76,12 @@ const SynthNodeOutputs = memo(function SynthNodeOutputs(props) {
         i.posY = py;
         i.posX = synthNode.x;
 
-        const loosePosX = synthNode.x;
-        const loosePosY = synthNode.y + i.posY;
+        const loosePosX = pxAsRem(synthNode.x);
+        const loosePosY = pxAsRem(synthNode.y + i.posY);
 
         return (
           <g key={i.id} className="terminal-group">
-            <title>{i.description}</title>
+            <title>{nodeTypeOutput.description}</title>
             <rect
               className={`drag-zone${ draggingLinkFromOutput ? ' hidden' : ''}`}
               x={asRem(synthNode.x + synthNode.w - dragLeft)}
@@ -89,8 +94,8 @@ const SynthNodeOutputs = memo(function SynthNodeOutputs(props) {
                 targetOutput: i,
                 loosePosX,
                 loosePosY,
-                prevPageX: pxAsRem(loosePosX),
-                prevPageY: pxAsRem(loosePosX),
+                prevPageX: loosePosX,
+                prevPageY: loosePosY,
               })}
               onMouseUp={(e) => handleMouseUp(e, {
                 // stop dragging a link from an Input to this Output
@@ -98,8 +103,8 @@ const SynthNodeOutputs = memo(function SynthNodeOutputs(props) {
                 targetOutput: i,
                 loosePosX,
                 loosePosY,
-                prevPageX: pxAsRem(loosePosX),
-                prevPageY: pxAsRem(loosePosX),
+                prevPageX: loosePosX,
+                prevPageY: loosePosY,
               })}
               onMouseDown={(e) => handleMouseDown(e, {
                 // New: begin dragging a link from this Output to an Input
@@ -127,7 +132,7 @@ const SynthNodeOutputs = memo(function SynthNodeOutputs(props) {
               className="terminal-output-label"
               x={asRem(synthNode.x + synthNode.w - labelPadding)}
               y={asRem(synthNode.y + py + 0.06)}
-            >{i.displayName}</text>
+            >{nodeTypeOutput.displayName}</text>
           </g>
         );
 

--- a/src/components/inspector/FormPatchNodeInputItem.jsx
+++ b/src/components/inspector/FormPatchNodeInputItem.jsx
@@ -1,5 +1,6 @@
 import './FormPatchNodeInputItem.css'
-import { joinItems } from '../../lib/utils.js'
+import { joinItems, getItemById } from '../../lib/utils.js'
+import { getNodeTypeById } from '../../lib/synthNodeTypes.js'
 import usePatchStore from '../../store/patchStore.jsx'
 import { getSynthNodeTerminalIntentsById } from '../../lib/synthNodeIntents';
 
@@ -8,8 +9,12 @@ function FormPatchNodeInputItem(props) {
   const setInputValue = usePatchStore((state) => state.setInputValue);
   const setInputExposed = usePatchStore((state) => state.setInputExposed);
 
-  const { inputItem } = props;
-  const intent = getSynthNodeTerminalIntentsById(inputItem.intentId);
+  const { inputItem, synthNode } = props;
+
+  const nodeType = getNodeTypeById(synthNode.nodeTypeId);
+  const nodeTypeInput = getItemById(nodeType.inputs, inputItem.id); // get matching input in synthNodeTypes
+
+  const intent = getSynthNodeTerminalIntentsById(nodeTypeInput.intentId);
   const { name, description } = intent;
   const hint = joinItems([name, description], ': ');;
 
@@ -21,19 +26,19 @@ function FormPatchNodeInputItem(props) {
     setInputExposed(inputItem, event.target.checked);
   }
 
-  const displayUnits = (inputItem.displayUnits) ? (
+  const displayUnits = (nodeTypeInput.displayUnits) ? (
     // not using this yet
-    <div className="units">{inputItem.displayUnits}</div>
+    <div className="units">{nodeTypeInput.displayUnits}</div>
   ) : <></>
 
-  const inputFieldVisible = (!inputItem.exposed || inputItem.isOffset)
+  const inputFieldVisible = (!inputItem.exposed || nodeTypeInput.isOffset)
   const inputField = <input
       className={`number ${inputFieldVisible ? '' : ' invisible'}`}
       onBlur={handleChangeValue}
       defaultValue={
         (inputItem.userValue !== undefined) ? inputItem.userValue :
         (inputItem.value !== undefined) ? inputItem.value :
-        inputItem.defaultValue
+        nodeTypeInput.defaultValue
       }
       title={hint}
     ></input>
@@ -48,12 +53,12 @@ function FormPatchNodeInputItem(props) {
   ) : <></>
 
   const rowClassNames = ['form-input-row'];
-  if (inputItem.placeholder) rowClassNames.push('placeholder');
+  if (nodeTypeInput.isPlaceholder) rowClassNames.push('placeholder');
 
-  const effectiveStateValue = inputItem.value !== undefined ? inputItem.value : inputItem.defaultValue;
+  const effectiveStateValue = inputItem.value !== undefined ? inputItem.value : nodeTypeInput.defaultValue;
   const trueValue = (
     inputItem.userValue &&    
-    (inputItem.value || inputItem.defaultValue) &&
+    (inputItem.value || nodeTypeInput.defaultValue) &&
     (parseFloat(inputItem.userValue) != effectiveStateValue))
   ? <div className="true-value">{effectiveStateValue.toFixed(4)}</div>
   : <></>
@@ -62,7 +67,7 @@ function FormPatchNodeInputItem(props) {
     <>
       <div className={rowClassNames.join(' ')} key={inputItem.id} role='listitem'>
         <div className="exposure">{exposureField}</div>
-        <div className="label" title={inputItem.description}>{inputItem.displayName}</div>
+        <div className="label" title={nodeTypeInput.description}>{nodeTypeInput.displayName}</div>
         {inputField}
       </div>
       {trueValue}

--- a/src/components/inspector/FormPatchNodeInputList.jsx
+++ b/src/components/inspector/FormPatchNodeInputList.jsx
@@ -8,7 +8,7 @@ function FormPatchNodeInputList(props) {
   
   return (
     (inputs || []).map(i => (
-      <FormPatchNodeInputItem key={`${synthNode.id}-${i.id}`} inputItem={i} />
+      <FormPatchNodeInputItem key={`${synthNode.id}-${i.id}`} inputItem={i} synthNode={synthNode}/>
     ))
   )
 }

--- a/src/components/inspector/PatchPersistencePanel.jsx
+++ b/src/components/inspector/PatchPersistencePanel.jsx
@@ -1,10 +1,13 @@
 import { appInfo } from '../../lib/appInfo.js'
 import saveAs from '../../lib/FileSaver.js'
 import usePatchStore from '../../store/patchStore.jsx'
+import { getNodeTypeById } from '../../lib/synthNodeTypes.js'
+import { getItemById } from '../../lib/utils.js'
 
-function SynthGraphProperties() {
+const SynthGraphProperties = () => {
 
   const state = usePatchStore.getState();
+
   const importExpanded = usePatchStore((state) => state.ui.importExpanded);
   const setImportExpanded = usePatchStore((state) => state.setImportExpanded);
 
@@ -14,6 +17,46 @@ function SynthGraphProperties() {
     // clean up state
     delete state.ui.draggingLinkFromOutput;
     delete state.ui.draggingLinkFromInput;
+
+    state.nodes.forEach(node => {
+      delete node.highlighted;
+      delete node.selected;
+
+      node.inputs.forEach(input => {
+        // clear up old properties not used now - remove at v1.0
+        delete input.displayName;
+        delete input.displayNameShort;
+        delete input.description;
+        delete input.defaultValue;
+        delete input.placeholder;
+        delete input.isPlaceholder;
+        delete input.intentId;
+        delete input.displayUnits;
+        delete input.isOffset;
+        if (input.link == {}) delete input.link;
+
+        // userValues are only useful if different (parseable format) from value.
+        if (input.userValue == input.value) delete input.userValue;
+
+        // delete values identical to default (consider removing if defaults are likely to change)
+        const nodeType = getNodeTypeById(node.nodeTypeId);
+        const nodeTypeInput = getItemById(nodeType.inputs, input.id); // get matching input in synthNodeTypes
+        if (input.value == nodeTypeInput.defaultValue) delete input.value;
+
+      })
+
+      node.outputs.forEach(output => {
+        // clear up old properties not used now - remove at v1.0
+        delete output.displayName;
+        delete output.displayNameShort;
+        delete output.description;
+        delete output.intentId;
+        delete output.displayUnits;
+        delete output.isOffset;
+        delete output.signal;
+      })
+    })
+  
 
     // add some metadata
     state.appName = appInfo.appName;

--- a/src/lib/appInfo.js
+++ b/src/lib/appInfo.js
@@ -1,8 +1,8 @@
 const appInfo = {
   appName: 'boop',
-  appVersion: '0.0.1.018',
-  appDate: '2025-01-09',
-  saveVersion: '0.0.1',
+  appVersion: '0.0.1.019',
+  appDate: '2025-01-13',
+  saveVersion: '0.0.2',
   specialVersionName: 'Early access',
   specialVersionAbout: 'Limited accessibility, no output parameter editing, some bugs known',
   authorName: 'j5v',

--- a/src/lib/synthNodeTypes.js
+++ b/src/lib/synthNodeTypes.js
@@ -38,7 +38,7 @@ const synthNodeTypes = {
         description: 'A waveform or sample',
         intentId: synthNodeTerminalIntents.SOURCE.id,
         exposed: false,
-        placeholder: true,
+        isPlaceholder: true,
         defaultValue: 1,
       },
       {

--- a/src/store/patchStore.jsx
+++ b/src/store/patchStore.jsx
@@ -101,10 +101,10 @@ const usePatchStore = create(
       viewAll: (vw = 400, vh = 300) => set((state) => {
 
         const bounds = {
-          top: 0,
-          right: 0,
-          bottom: 0,
-          left: 0,
+          top: Infinity,
+          right: -Infinity,
+          bottom: -Infinity,
+          left: Infinity,
         }
 
         state.nodes.forEach(node => {


### PR DESCRIPTION
`synthNode` objects were bloated becuase they contained static data from `synthNodeTypes`, so I:
1. normalized the data lookup to use `synthNodeTypes`
2. Deleted those properties when saving (but will not need to delete them in future, because they won't be present).

Saved patch files are now a lot smaller, and less likely to retain junk as the app upgrades.

On testing the proposed changes, I found a big performance hit during synthesis, and found the new lookups were expensive. I forced missing `synthNodes.inputs[].value` to take on their `synthNodeType.inputs[].defaultValue` values, to avoid lookups in the synth processing loop. UI remains as lookups, but performance is not as critical there.